### PR TITLE
Consider local maven installation in MavenPom

### DIFF
--- a/src/version-hooks/maven.ts
+++ b/src/version-hooks/maven.ts
@@ -1,4 +1,5 @@
-import {ExecOptions} from 'child_process';
+import type {ExecOptions} from 'child_process';
+import {existsSync} from 'fs';
 import path from 'path';
 
 import type {ReleaseContext, VersionFunction} from '../types';
@@ -7,8 +8,10 @@ import {Command} from './command';
 
 export function MavenPom(options?: ExecOptions): VersionFunction {
 
-    const mavenPomCmd = (context: ReleaseContext) =>
-        `.${path.sep}mvnw versions:set -DnewVersion="${context.version.version}" -DgenerateBackupPoms=false`;
+    const mavenPomCmd = (context: ReleaseContext) => {
+        const mvn = existsSync(path.resolve(context.directory, 'mvnw')) ? `.${path.sep}mvnw` : 'mvn';
+        return `${mvn} versions:set -DnewVersion="${context.version.version}" -DgenerateBackupPoms=false`;
+    };
 
     return Command(mavenPomCmd, {maxBuffer: 1024 * 1024, ...options});
 }

--- a/test/version-hooks/command.mock.ts
+++ b/test/version-hooks/command.mock.ts
@@ -1,0 +1,28 @@
+import type {ExecOptions} from 'child_process';
+
+import * as CommandModule from '../../src/version-hooks/command';
+import type {ReleaseContext, VersionFunction} from '../../src/types';
+
+/**
+ * Mocks the Command version hook with a jest mock function and returns it to track the calls.
+ * The returned `jest.Mock` is always called with the real command string that would be passed
+ * to `child_process.exec` method. The optional `ExecOptions` are also tracked by the mock.
+ * 
+ * IMPORTANT: This function uses jest.spyOn to replace the real Command module. Therefore it is recommanded
+ * to add `afterEach(() => jest.restoreAllMocks());` to your test to restore the mock after the test case.
+ */
+export function mockCommand(): jest.Mock<Promise<void>, [cmdString: string, options?: ExecOptions]> {
+    const mock = jest.fn<Promise<void>, [cmdString: string, options?: ExecOptions]>(() => Promise.resolve());
+
+    const mockedCommand = (cmdString: string | ((context: ReleaseContext) => string), options?: ExecOptions):
+    VersionFunction => {
+        return (context: ReleaseContext) => {
+            const command = typeof cmdString === 'string' ? cmdString : cmdString(context);
+            return mock(command, options);
+        };
+    };
+
+    jest.spyOn(CommandModule, 'Command').mockImplementation(mockedCommand);
+
+    return mock;
+}

--- a/test/version-hooks/npm.spec.ts
+++ b/test/version-hooks/npm.spec.ts
@@ -8,15 +8,32 @@ import {NpmPackage} from '../../src/version-hooks';
 import {createTestDirectory, createReleaseContext} from '../test-utils';
 import type {ReleaseContext} from '../../src/types';
 
-let context: ReleaseContext;
-let testDir: string;
-
-beforeEach(() => {
-    testDir = createTestDirectory('TestPluginNpmPackage');
-    context = createReleaseContext(testDir);
-});
+import {mockCommand} from './command.mock';
 
 describe('Plugin NpmPackage', () => {
+    let context: ReleaseContext;
+    let testDir: string;
+
+    beforeEach(() => {
+        testDir = createTestDirectory('TestPluginNpmPackage');
+        context = createReleaseContext(testDir);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('creates correct npm command', async () => {
+        const mock = mockCommand();
+       
+        const plugin = NpmPackage();
+        context.version = new SemVer('1.1.0');
+        await plugin(context);
+
+        const expectedCmd = 'npm --no-git-tag-version --allow-same-version version 1.1.0';
+        expect(mock).toBeCalledWith(expectedCmd, undefined);
+    });
+
     it('updates version number', async () => {
         execSync('npm init -y', {cwd: testDir});
 


### PR DESCRIPTION
The MavenPom hook function now considers the local maven installation if no maven wrapper is present in the repository. If both a local maven installation and a maven wrapper are present the maven wrapper is used.

Fix #2